### PR TITLE
Cache calico-node docker image in slave image build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ADD ./calico_isolator.py /isolator/
 ADD ./configure.ac /isolator/
 ADD ./Makefile.am /isolator/
 ADD ./requirements.txt /isolator/
+ADD http://downloads.mesosphere.io/demo/calico-node/v0.5.1/calico-node-v0.5.1.tar /isolator/
 
 WORKDIR /isolator
 

--- a/init_scripts/etc/service/calico/run
+++ b/init_scripts/etc/service/calico/run
@@ -1,6 +1,7 @@
 #!/bin/sh
 IP=`ip addr | grep 'global eth0' | awk '{print $2}' | cut -f1  -d'/'`
 ETCD_IP=`getent hosts etcd | awk '{ print $2 }'`
+docker load -i /isolator/calico-node-v0.5.1.tar
 export ETCD_AUTHORITY=$ETCD_IP:4001
 exec 2>&1
-exec calicoctl node --ip=$IP --detach=false
+exec calicoctl node --ip=$IP --detach=false --node-image=calico/node:v0.5.1


### PR DESCRIPTION
Supersedes #29.