### PR TITLE
updated calico-node to v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ADD ./calico_isolator /isolator/
 ADD ./configure.ac /isolator/
 ADD ./Makefile.am /isolator/
 ADD ./requirements.txt /isolator/
-COPY ./calico-node-v0.5.4.tar /isolator/
+COPY ./calico-node-v0.6.0.tar /isolator/
 
 WORKDIR /isolator
 
@@ -58,7 +58,7 @@ VOLUME /var/lib/docker
 ###################
 # Calico
 ###################
-RUN wget https://github.com/projectcalico/calico-docker/releases/download/v0.5.4/calicoctl && \
+RUN wget https://github.com/projectcalico/calico-docker/releases/download/v0.6.0/calicoctl && \
     chmod +x calicoctl && \
     mv calicoctl /usr/local/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CALICO_NODE_VERSION=v0.5.4
+CALICO_NODE_VERSION=v0.6.0
 DOCKER_COMPOSE_URL=https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m`
 
 default: images
@@ -13,8 +13,8 @@ images: calico-node docker-compose
 calico-node: calico-node-$(CALICO_NODE_VERSION).tar
 
 calico-node-$(CALICO_NODE_VERSION).tar:
-	docker pull calico/node:v0.5.4
-	docker save -o calico-node-v0.5.4.tar calico/node:v0.5.4
+	docker pull calico/node:$(CALICO_NODE_VERSION)
+	docker save -o calico-node-$(CALICO_NODE_VERSION).tar calico/node:$(CALICO_NODE_VERSION)
 
 st: images
 	for container in netmodules_marathon_1 netmodules_mesosmaster_1 netmodules_zookeeper_1 netmodules_etcd_1 netmodules_slave1_1 netmodules_slave2_1 ; do \


### PR DESCRIPTION
Also updated calico_isolator binary to use stable release of libcalico 0.2.0 (ipam)