### PR TITLE
[DO NOT MERGE] Demo updates

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,12 +29,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Default value: false
   config.ssh.forward_agent = true
 
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  config.vm.synced_folder ".", "/home/vagrant/net-modules"
-
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   config.vm.provider "virtualbox" do |vb|
@@ -92,6 +86,11 @@ SCRIPT
     echo Finished setting up kernel modules
 SCRIPT
 
+  $get_netmodules_source = <<SCRIPT
+    git clone https://github.com/mesosphere/net-modules.git
+    echo Finished installing net-modules src
+SCRIPT
+
   config.vm.provision "shell", inline: $install_docker
 
   config.vm.provision "shell", inline: $install_docker_compose
@@ -107,5 +106,7 @@ SCRIPT
     d.pull_images "jplock/zookeeper:3.4.5"
     d.pull_images "spikecurtis/single-etcd"
   end
+
+  config.vm.provision "shell", inline: $get_netmodules_source, privileged: false
 
 end

--- a/demo/launch-cluster-before.sh
+++ b/demo/launch-cluster-before.sh
@@ -9,7 +9,7 @@ echo "Launching cluster with network isolation modules disabled..."
 
 pushd $DEMO_DIR/before
 docker-compose -p netmodules up -d
-docker-compose scale slave=2
+docker-compose -p netmodules scale slave=2
 popd
 
 $DEMO_DIR/add-container-route.sh


### PR DESCRIPTION
Running the Vagrant Demo from a Windows host will clone the net-modules repo locally with Windows line endings. That code is then mounted into the Ubuntu Vagrant VM, maintaining those line endings, which eventually produces an error when the Dockerfile is interpreted.

This fix removes the volume mount and instead clones the repo from within the Ubuntu VM, so the source code is downloaded with the appropriate Unix line endings