### PR TITLE
Remove reference to ifconfig

### DIFF
--- a/framework/calico_executor.py
+++ b/framework/calico_executor.py
@@ -88,7 +88,7 @@ class ExecutorTask(object):
         print "Running task %s" % self.id
         self.send_update(mesos_pb2.TASK_RUNNING)
 
-        print subprocess.check_output(["ifconfig"])
+        print subprocess.check_output(["ip", "addr"])
 
     def run_task(self):
         raise NotImplementedError

--- a/framework/calico_framework.py
+++ b/framework/calico_framework.py
@@ -533,10 +533,9 @@ class TestScheduler(mesos.interface.Scheduler):
 
 
 def get_host_ip():
-    interface_dump = subprocess.check_output(["ifconfig", "eth0"])
-    re_find_ip = r'inet addr:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
-    result = re.findall(re_find_ip, interface_dump)
-    return result.pop()
+    ip = subprocess.Popen('ip route get 8.8.8.8 | head -1 | cut -d\' \' -f8',
+                          shell=True, stdout=subprocess.PIPE).stdout.read()
+    return ip.strip()
 
 
 class NotEnoughResources(Exception):


### PR DESCRIPTION
We cannot not rely on ifconfig because baremetal CentOS7 does not have ifconfig installed. Also we cannot assume that eth0 will always be the default interface name. Use ip commands instead.