### PR TITLE
Use mesos-dns 0.4.0 binary in slave Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ MAINTAINER Spike Curtis <spike@projectcalico.org>
 ####################
 # Mesos-DNS
 ####################
-RUN wget https://dl.dropboxusercontent.com/u/4550074/mesos/mesos-dns+50fc45a9 -O /usr/bin/mesos-dns && \
+RUN curl -LO https://github.com/mesosphere/mesos-dns/releases/download/v0.4.0/mesos-dns-v0.4.0-linux-amd64.gz && \
+    gunzip mesos-dns-v0.4.0-linux-amd64.gz && \
+    mv mesos-dns-v0.4.0-linux-amd64 /usr/bin/mesos-dns && \
     chmod +x /usr/bin/mesos-dns
 
 ###################


### PR DESCRIPTION
Update the mesos slave to use mesos-dns 0.4.0, which includes NetworkInfo support (f8e818947fa15e138d93226e49d23fae9824a963).