### PR TITLE
[Do not merge] Open firewall ports with unit config files

### DIFF
--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -76,6 +76,8 @@ ADD ./sources/mesos/quorum /root/rpmbuild/SOURCES/quorum
 ADD ./sources/mesos/work_dir /root/rpmbuild/SOURCES/work_dir
 ADD ./sources/mesos/mesos-init-wrapper /root/rpmbuild/SOURCES/mesos-init-wrapper
 ADD ./sources/mesos/zk /root/rpmbuild/SOURCES/zk
+ADD ./sources/mesos/firewall-agent.service /root/rpmbuild/SOURCES/firewall-agent.service
+ADD ./sources/mesos/firewall-master.service /root/rpmbuild/SOURCES/firewall-master.service
 
 # MESOS
 ADD ./mesos.spec /root/mesos.spec

--- a/packages/mesos.spec
+++ b/packages/mesos.spec
@@ -17,6 +17,8 @@ Source6:       quorum
 Source7:       work_dir
 Source8:       mesos-init-wrapper
 Source9:       zk
+Source10:      firewall-agent.service
+Source11:      firewall-master.service
 
 BuildRequires: libtool
 BuildRequires: automake
@@ -182,6 +184,7 @@ install -m 0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/default/
 
 mkdir -p %{buildroot}%{_unitdir}
 install -m 0644 %{SOURCE4} %{SOURCE5} %{buildroot}%{_unitdir}/
+install -m 0644 %{SOURCE10} %{SOURCE11} %{buildroot}%{_unitdir}/
 
 mkdir -p %{buildroot}%{_sysconfdir}/%{name}-master
 install -m 0644 %{SOURCE6} %{SOURCE7} %{buildroot}%{_sysconfdir}/%{name}-master/
@@ -210,6 +213,8 @@ mkdir -p -m0755 %{buildroot}/%{_var}/lib/%{name}
 %attr(0755,mesos,mesos) %{_var}/lib/%{name}/
 %config(noreplace) %{_sysconfdir}/default/%{name}*
 %{_unitdir}/%{name}*.service
+%{_unitdir}/firewall-agent.service
+%{_unitdir}/firewall-master.service
 %{_sysconfdir}/%{name}-master/*
 %{_sysconfdir}/%{name}-slave
 %{_sysconfdir}/%{name}/*
@@ -251,14 +256,14 @@ fi
 exit 0
 
 %post
-%systemd_post %{name}-slave.service %{name}-master.service
+%systemd_post %{name}-slave.service %{name}-master.service firewall-agent.service firewall-master.service
 /sbin/ldconfig
 
 %preun
-%systemd_preun %{name}-slave.service %{name}-master.service
+%systemd_preun %{name}-slave.service %{name}-master.service firewall-agent.service firewall-master.service
 
 %postun
-%systemd_postun_with_restart %{name}-slave.service %{name}-master.service
+%systemd_postun_with_restart %{name}-slave.service %{name}-master.service firewall-agent.service firewall-master.service
 /sbin/ldconfig
 
 

--- a/packages/sources/mesos/firewall-agent.service
+++ b/packages/sources/mesos/firewall-agent.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=firewall-agent
+After=firewalld.service
+Requires=firewalld.service
+
+[Service]
+User=root
+PermissionsStartOnly=true
+ExecStartPre=/usr/bin/firewall-cmd --zone=public --add-port=179/tcp --permanent
+ExecStartPre=/usr/bin/firewall-cmd --zone=public --add-port=5051/tcp --permanent
+ExecStart=/usr/bin/firewall-cmd --reload
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/sources/mesos/firewall-master.service
+++ b/packages/sources/mesos/firewall-master.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=firewall-master
+After=firewalld.service
+Requires=firewalld.service
+
+[Service]
+User=root
+PermissionsStartOnly=true
+ExecStartPre=/usr/bin/firewall-cmd --zone=public --add-port=2181/tcp --permanent
+ExecStartPre=/usr/bin/firewall-cmd --zone=public --add-port=5050/tcp --permanent
+ExecStartPre=/usr/bin/firewall-cmd --zone=public --add-port=2379/tcp --permanent
+ExecStartPre=/usr/bin/firewall-cmd --zone=public --add-port=4001/tcp --permanent
+ExecStartPre=/usr/bin/firewall-cmd --zone=public --add-port=8080/tcp --permanent
+ExecStart=/usr/bin/firewall-cmd --reload
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Automate the process of configuring the fallwalls on each node with a systemd unit file.

Agent node requires:

| Service Name | Port/protocol     |
|--------------|-------------------|
| BIRD (BGP)   | 179/tcp           |
| mesos-agent  | 5051/tcp          |

Master node requires:

| Service Name | Port/protocol     |
|--------------|-------------------|
| zookeeper    | 2181/tcp          |
| mesos-master | 5050/tcp          |
| etcd         | 2379/tcp 4001/tcp |
| marathon     | 8080/tcp          |