### PR TITLE
Fix Deactivated Netmodules

### DIFF
--- a/isolator/isolator/network_isolator.cpp
+++ b/isolator/isolator/network_isolator.cpp
@@ -159,6 +159,7 @@ Try<Isolator*> NetworkIsolatorProcess::create(const Parameters& parameters)
   foreach (const Parameter& parameter, parameters.parameter()) {
     if (parameter.key() == ipamClientKey) {
       ipamPathSpecified = true;
+      ipamClientPath = parameter.value();
     } else if (parameter.key() == isolatorClientKey) {
       isolatorPathSpecified = true;
       isolatorClientPath = parameter.value();


### PR DESCRIPTION
Added missing line to record ipam client path. This should resolve bug that was preventing netmodules from loading (#87)