### PR TITLE
Removed dependency on docker

### DIFF
--- a/packages/mesos.spec
+++ b/packages/mesos.spec
@@ -60,7 +60,6 @@ BuildRequires: http-parser-devel
 
 Requires: python-boto
 Requires: cyrus-sasl-md5
-Requires: docker
 
 # The slaves will indirectly require time syncing with the master
 # nodes so just call out the dependency.


### PR DESCRIPTION
Docker provides the official `docker-engine` package which is guaranteed to be up to date in the official docker repository. The `docker` package removed in this PR is the centos provided package, which is several version out of date. Though we could require it instead, I believe its best to not require docker, and allow systemd to spit errors if it can't find a `docker.service` (which both packages do provide)